### PR TITLE
fix: support no unchecked index access tsconfig option

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "peerDependencies": {
     "@rbxts/jecs": "0.9.x || >=0.9.0-rc.12",
-    "typescript": "5.8.x"
+    "typescript": ">=5.5.0"
   },
   "devDependencies": {
     "@types/ts-expose-internals": "npm:ts-expose-internals@5.6.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
         specifier: 0.9.x || >=0.9.0-rc.12
         version: 0.9.0-rc.12
       typescript:
-        specifier: 5.8.x
+        specifier: '>=5.5.0'
         version: 5.8.3
     devDependencies:
       '@eslint/js':

--- a/src/index.ts
+++ b/src/index.ts
@@ -419,12 +419,14 @@ const transformerInner = (
 										el,
 										undefined,
 										undefined,
-										ts.factory.createElementAccessExpression(
-											key,
-											ts.factory.createBinaryExpression(
-												row,
-												ts.factory.createToken(ts.SyntaxKind.MinusToken),
-												ts.factory.createNumericLiteral("1"),
+										ts.factory.createNonNullExpression(
+											ts.factory.createElementAccessExpression(
+												key,
+												ts.factory.createBinaryExpression(
+													row,
+													ts.factory.createToken(ts.SyntaxKind.MinusToken),
+													ts.factory.createNumericLiteral("1"),
+												),
 											),
 										),
 									),
@@ -516,9 +518,11 @@ const transformerInner = (
 																		key,
 																		undefined,
 																		undefined,
-																		ts.factory.createElementAccessExpression(
-																			field,
-																			ct,
+																		ts.factory.createNonNullExpression(
+																			ts.factory.createElementAccessExpression(
+																				field,
+																				ct,
+																			),
 																		),
 																	),
 																),
@@ -591,15 +595,18 @@ const transformerInner = (
 																				entity.name,
 																				undefined,
 																				undefined,
-																				ts.factory.createElementAccessExpression(
-																					entities,
-																					ts.factory.createBinaryExpression(
-																						row,
-																						ts.factory.createToken(
-																							ts.SyntaxKind.MinusToken,
-																						),
-																						ts.factory.createNumericLiteral(
-																							"1",
+																				ts.factory.createNonNullExpression(
+																					ts.factory.createElementAccessExpression(
+																						entities,
+																						ts.factory.createBinaryExpression(
+																							row,
+																							ts.factory.createToken(
+																								ts.SyntaxKind
+																									.MinusToken,
+																							),
+																							ts.factory.createNumericLiteral(
+																								"1",
+																							),
 																						),
 																					),
 																				),

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -14,6 +14,7 @@
 		"forceConsistentCasingInFileNames": true,
 		"moduleDetection": "force",
 		"strict": true,
+		"noUncheckedIndexedAccess": true,
 		"target": "ESNext",
 		"typeRoots": [
 			"node_modules/@rbxts"


### PR DESCRIPTION
When using the tsconfig option `noUncheckedIndexedAccess`, array access turns from `T` into `T | undefined`. Because of the arrays that the transformer produces, this causes the compiler to error as we're now trying to access properties that are undefined.

This PR just adds the non-null expression (`!`) after the array access to ensure that it's defined and does not error.