### PR TITLE
fix: skip caching for uninitialized and locally-declared worlds

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -180,8 +180,7 @@ const transformerInner = (
 					const worldSymbol = typeChecker.getSymbolAtLocation(world)
 					assert(worldSymbol, "Cannot resolve type of world")
 
-					if (isLocallyDeclared(worldSymbol)) {
-						//} || !hasInitializer(worldSymbol)) {
+					if (isLocallyDeclared(worldSymbol) || !hasInitializer(worldSymbol)) {
 						return node
 					}
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -86,14 +86,18 @@ export const hasInitializer = (symbol: ts.Symbol): boolean => {
 	if (!decls) return false
 
 	const decl = decls[0]
+
+	// Variable declarations may or may not have initializers
 	if (ts.isVariableDeclaration(decl)) {
 		return decl.initializer !== undefined
 	}
 
+	// Parameters are "initialized" by the caller
 	if (ts.isParameter(decl)) {
-		return false
+		return true
 	}
 
+	// Other declarations (imports, functions, etc.) are considered initialized
 	return true
 }
 

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -74,6 +74,12 @@ export const functionWithWorldCreation = () => {
 	}
 }
 
+export const directParamWorld = (world: _world) => {
+	for (const [e, a] of world.query(A, B)) {
+		if (math.random() > 0.5) break
+	}
+}
+
 declare function beforeEach(cb: () => void): void
 declare function describe(name: string, cb: () => void): void
 declare function it(name: string, cb: () => void): void


### PR DESCRIPTION
## Problem

The transformer broke when using worlds declared without initializers, causing "used before declaration" errors. This commonly happens in test frameworks:

```typescript
let world: World  // No initializer

beforeEach(() => {
  world = Jecs.world()  // Initialized in hook
})

it("test", () => {
  for (const [e] of world.query(A)) { }  // ❌ Error
})

```

In these cases it makes little sense to cache anyway, so I think it makes most sense to skip the optimization.

I could not think of a case where a user would want to cache while declaring world scope together, so I think this makes sense. 